### PR TITLE
Add ElevenLabs conversational engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ API para el Agente de Ventas NGX con IA conversacional que aprovecha OpenAI para
 ### Capacidades Principales
 - 🧠 **Procesamiento de Lenguaje Natural**: Utiliza GPT-4 para mantener conversaciones contextuales y naturales.
 - 🗣️ **Síntesis de Voz Avanzada**: Integración con ElevenLabs para generar respuestas de voz naturales y expresivas.
+- 🗨️ **Conversaciones en Tiempo Real**: Compatible con la API conversacional de
+  ElevenLabs 2.0 para iniciar sesiones de voz y enviar mensajes de manera
+  interactiva.
 - 💾 **Persistencia en Supabase**: Almacenamiento de conversaciones y datos de clientes en PostgreSQL mediante Supabase.
 - 🔄 **Arquitectura Asíncrona**: API completamente asíncrona para manejar múltiples conversaciones simultáneas.
 - 🚀 **Containerización con Docker**: Facilidad de despliegue y desarrollo mediante contenedores.
@@ -154,6 +157,18 @@ curl -X 'POST' \
   -d '{
     "message": "Me interesa mejorar mi energía durante el día."
   }'
+```
+
+### Usar ElevenLabs Conversational Engine
+
+```python
+from src.integrations.elevenlabs import ConversationalEngine
+
+engine = ConversationalEngine()
+engine.start(agent_id="YOUR_AGENT_ID")
+engine.send_message("Hola, ¿cómo estás?")
+audio = engine.get_audio()
+engine.end()
 ```
 
 ## Plan de Mejora

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ openai-agents
 langchain==0.0.312
 
 # Procesamiento de voz
-elevenlabs
+elevenlabs==2.1.0
 librosa==0.10.1
 soundfile==0.12.1
 

--- a/src/integrations/elevenlabs/__init__.py
+++ b/src/integrations/elevenlabs/__init__.py
@@ -1,4 +1,10 @@
 # Este archivo permite que el directorio sea tratado como un paquete de Python
 from .voice import VoiceEngine, ProgramVoice, voice_engine
+from .conversation import ConversationalEngine
 
-__all__ = ["VoiceEngine", "ProgramVoice", "voice_engine"] 
+__all__ = [
+    "VoiceEngine",
+    "ProgramVoice",
+    "voice_engine",
+    "ConversationalEngine",
+]

--- a/src/integrations/elevenlabs/conversation.py
+++ b/src/integrations/elevenlabs/conversation.py
@@ -1,0 +1,75 @@
+import os
+import logging
+from io import BytesIO
+from typing import Optional
+from dotenv import load_dotenv
+
+try:
+    from elevenlabs import ElevenLabs
+    from elevenlabs.conversational_ai import Conversation
+    from elevenlabs.conversational_ai.conversation import AudioInterface
+except Exception as e:  # pragma: no cover - library may not be installed in tests
+    ElevenLabs = None  # type: ignore
+    Conversation = None  # type: ignore
+    AudioInterface = object  # type: ignore
+    logging.getLogger(__name__).warning(f"ElevenLabs import failed: {e}")
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+
+
+class BufferedAudioInterface(AudioInterface):
+    """Simple audio interface that stores audio output in memory."""
+
+    def __init__(self) -> None:
+        self.buffer = BytesIO()
+
+    def start(self, input_callback):  # type: ignore[override]
+        # This engine only handles text input, so we ignore the callback
+        pass
+
+    def stop(self) -> None:  # type: ignore[override]
+        pass
+
+    def output(self, audio: bytes) -> None:  # type: ignore[override]
+        self.buffer.write(audio)
+
+    def interrupt(self) -> None:  # type: ignore[override]
+        pass
+
+
+class ConversationalEngine:
+    """Wrapper around ElevenLabs conversational AI."""
+
+    def __init__(self, api_key: Optional[str] = None) -> None:
+        self.api_key = api_key or os.getenv("ELEVENLABS_API_KEY")
+        self.client = ElevenLabs(api_key=self.api_key) if ElevenLabs else None
+        self.conversation: Optional[Conversation] = None
+        self.audio_interface = BufferedAudioInterface()
+
+    def start(self, agent_id: str, requires_auth: bool = True) -> None:
+        if not self.client or not Conversation:
+            raise RuntimeError("ElevenLabs client not available")
+        self.conversation = Conversation(
+            client=self.client,
+            agent_id=agent_id,
+            requires_auth=requires_auth,
+            audio_interface=self.audio_interface,
+        )
+        self.conversation.start_session()
+
+    def send_message(self, text: str) -> None:
+        if not self.conversation:
+            raise RuntimeError("Conversation not started")
+        self.conversation.send_user_message(text)
+
+    def end(self) -> Optional[str]:
+        if not self.conversation:
+            return None
+        self.conversation.end_session()
+        conv_id = self.conversation.wait_for_session_end()
+        self.conversation = None
+        return conv_id
+
+    def get_audio(self) -> BytesIO:
+        return BytesIO(self.audio_interface.buffer.getvalue())


### PR DESCRIPTION
## Summary
- update to ElevenLabs 2.1.0
- add new `ConversationalEngine` wrapper using ElevenLabs Conversational AI
- expose the conversational engine in the package
- guard voice engine imports when ElevenLabs is unavailable
- document new real-time conversation capability

## Testing
- `pytest test_intent_analysis.py::test_intent_analysis -q`
- `pytest -q` *(fails: Fixture 'customer_name' not found, missing plugins)*

------
https://chatgpt.com/codex/tasks/task_e_6840cba1058c8323a66ed5eb58ae5adb